### PR TITLE
Trim comma-separated keywords

### DIFF
--- a/src/core/data/query_params.py
+++ b/src/core/data/query_params.py
@@ -170,7 +170,7 @@ class CombinationParams(CSVParams):
             and len(value) == 1
             and isinstance(value[0], str)
         ):
-            keywords = value[0].split(",")
+            keywords = [keyword.strip() for keyword in value[0].split(",")]
             if len(keywords) < 2:
                 raise ValidationError.from_exception_data(
                     "Keywords length too short",

--- a/tests/unitary/test_query_params.py
+++ b/tests/unitary/test_query_params.py
@@ -90,6 +90,10 @@ def test_combination_params_keywords():
     model = CombinationParams(**raw)
     assert model.keywords == ["any", "any"]
 
+    raw.update({"keywords": [" any, any "]})
+    model = CombinationParams(**raw)
+    assert model.keywords == ["any", "any"]
+
     raw.update({"keywords": ["any,any,any,any,any"]})
     with raises(ValidationError) as info:
         CombinationParams(**raw)


### PR DESCRIPTION
## Summary
- trim comma-separated keyword values before query validation
- preserve existing keyword list validation
- add a regression test for spaced comma keyword input

## Validation
- direct query parameter validation passed
- syntax checks passed
- pytest is blocked by missing compiled locale files in this checkout